### PR TITLE
Adding function as a valid value to add()

### DIFF
--- a/gsap.d.ts
+++ b/gsap.d.ts
@@ -465,7 +465,7 @@ declare namespace GSAPStatic {
 	   * @returns {Timeline}
 	   * @memberof Timeline
 	   */
-		add(value: Tween | Timeline | string | string[], position?: positionType, align?: string, stagger?: number | string): this;
+		add(value: Tween | Timeline | string | string[] | Function, position?: positionType, align?: string, stagger?: number | string): this;
 
 
 


### PR DESCRIPTION
Hello! Excellent library, thanks for the hard work! I know PR 319 exists, but I independently noticed the bug and I figured I'd offer up a more piecemeal fix for the `TimeLine.add` declaration if you're interested in it for a smaller patch release.

Here's an example that's not compiling for me FWIW.

```typescript
import gsap from 'gsap'; // Assuming 3.0.1

const t = gsap.timeline();
t.add(() => console.log('Hello world'));
```

Thanks again!