### PR TITLE
delayedCall can take params of any type but is currently restricted to strings

### DIFF
--- a/gsap.d.ts
+++ b/gsap.d.ts
@@ -698,7 +698,7 @@ declare namespace GSAPStatic {
 
 
 
-    delayedCall(delay: number, callback: callbackFn, params?: string[], scope?: any): Tween; // TODO: investigate scope, try to eliminate 'any'
+    delayedCall(delay: number, callback: callbackFn, params?: any[], scope?: any): Tween; // TODO: investigate scope, try to eliminate 'any'
 
 
 


### PR DESCRIPTION
Updated typings. delayedCall can take params of any type but is currently restricted to strings. Changed that so that the parameters are of type any.