### PR TITLE
docs: Fix simple typo, tweenng -> tweening

### DIFF
--- a/esm/gsap-core.js
+++ b/esm/gsap-core.js
@@ -3166,7 +3166,7 @@ export var Tween = /*#__PURE__*/function (_Animation2) {
 
     if (this.timeline) {
       var tDur = this.timeline.totalDuration();
-      this.timeline.killTweensOf(targets, vars, _overwritingTween && _overwritingTween.vars.overwrite !== true)._first || _interrupt(this); // if nothing is left tweenng, interrupt.
+      this.timeline.killTweensOf(targets, vars, _overwritingTween && _overwritingTween.vars.overwrite !== true)._first || _interrupt(this); // if nothing is left tweening, interrupt.
 
       this.parent && tDur !== this.timeline.totalDuration() && _setDuration(this, this._dur * this.timeline._tDur / tDur, 0, 1); // if a nested tween is killed that changes the duration, it should affect this tween's duration. We must use the ratio, though, because sometimes the internal timeline is stretched like for keyframes where they don't all add up to whatever the parent tween's duration was set to.
 

--- a/src/gsap-core.js
+++ b/src/gsap-core.js
@@ -2359,7 +2359,7 @@ export class Tween extends Animation {
 		}
 		if (this.timeline) {
 			let tDur = this.timeline.totalDuration();
-			this.timeline.killTweensOf(targets, vars, _overwritingTween && _overwritingTween.vars.overwrite !== true)._first || _interrupt(this); // if nothing is left tweenng, interrupt.
+			this.timeline.killTweensOf(targets, vars, _overwritingTween && _overwritingTween.vars.overwrite !== true)._first || _interrupt(this); // if nothing is left tweening, interrupt.
 			this.parent && tDur !== this.timeline.totalDuration() && _setDuration(this, this._dur * this.timeline._tDur / tDur, 0, 1); // if a nested tween is killed that changes the duration, it should affect this tween's duration. We must use the ratio, though, because sometimes the internal timeline is stretched like for keyframes where they don't all add up to whatever the parent tween's duration was set to.
 			return this;
 		}


### PR DESCRIPTION
There is a small typo in esm/gsap-core.js, src/gsap-core.js.

Should read `tweening` rather than `tweenng`.

