### PR TITLE
Add text plugin control text right to left feature

### DIFF
--- a/src/TextPlugin.js
+++ b/src/TextPlugin.js
@@ -47,7 +47,7 @@ export const TextPlugin = {
 			original = text;
 			text = i;
 		}
-		data.reverse = value.reverse;
+		data.rtl = value.rtl;
 		data.hasClass = !!(value.newClass || value.oldClass);
 		data.newClass = value.newClass;
 		data.oldClass = value.oldClass;
@@ -98,12 +98,12 @@ export const TextPlugin = {
 		if (data.from) {
 			ratio = 1 - ratio;
 		}
-		let { text, hasClass, newClass, oldClass, delimiter, target, fillChar, original ,reverse} = data,
+		let { text, hasClass, newClass, oldClass, delimiter, target, fillChar, original ,rtl} = data,
 			l = text.length,
 			i = (ratio * l + 0.5) | 0,
 			applyNew, applyOld, str,addStr;
 		
-		if(reverse){
+		if(rtl){
 			addStr = original.slice(0,original.length - i).join(delimiter)
 		}else{
 			addStr = original.slice(i).join(delimiter)

--- a/src/TextPlugin.js
+++ b/src/TextPlugin.js
@@ -47,6 +47,7 @@ export const TextPlugin = {
 			original = text;
 			text = i;
 		}
+		data.reverse = value.reverse;
 		data.hasClass = !!(value.newClass || value.oldClass);
 		data.newClass = value.newClass;
 		data.oldClass = value.oldClass;
@@ -97,16 +98,24 @@ export const TextPlugin = {
 		if (data.from) {
 			ratio = 1 - ratio;
 		}
-		let { text, hasClass, newClass, oldClass, delimiter, target, fillChar, original } = data,
+		let { text, hasClass, newClass, oldClass, delimiter, target, fillChar, original ,reverse} = data,
 			l = text.length,
 			i = (ratio * l + 0.5) | 0,
-			applyNew, applyOld, str;
+			applyNew, applyOld, str,addStr;
+		
+		if(reverse){
+			addStr = original.slice(0,original.length - i)
+		}else{
+			addStr = original.slice(i).join(delimiter)
+		}
+		
+		
 		if (hasClass && ratio) {
 			applyNew = (newClass && i);
 			applyOld = (oldClass && i !== l);
-			str = (applyNew ? "<span class='" + newClass + "'>" : "") + text.slice(0, i).join(delimiter) + (applyNew ? "</span>" : "") + (applyOld ? "<span class='" + oldClass + "'>" : "") + delimiter + original.slice(i).join(delimiter) + (applyOld ? "</span>" : "");
+			str = (applyNew ? "<span class='" + newClass + "'>" : "") + text.slice(0, i).join(delimiter) + (applyNew ? "</span>" : "") + (applyOld ? "<span class='" + oldClass + "'>" : "") + delimiter + addStr + (applyOld ? "</span>" : "");
 		} else {
-			str = text.slice(0, i).join(delimiter) + delimiter + original.slice(i).join(delimiter);
+			str = text.slice(0, i).join(delimiter) + delimiter + addStr;
 		}
 		if (data.svg) { //SVG text elements don't have an "innerHTML" in Microsoft browsers.
 			target.textContent = str;

--- a/src/TextPlugin.js
+++ b/src/TextPlugin.js
@@ -104,7 +104,7 @@ export const TextPlugin = {
 			applyNew, applyOld, str,addStr;
 		
 		if(reverse){
-			addStr = original.slice(0,original.length - i)
+			addStr = original.slice(0,original.length - i).join(delimiter)
 		}else{
 			addStr = original.slice(i).join(delimiter)
 		}


### PR DESCRIPTION
As mentioned in these links, the text plugin of GSAP lacks the function to control the text order. At present, it only has the function from left to right. I have added the function from right to left

https://greensock.com/forums/topic/28296-backwards-writing-typewriter-with-textplugin/
https://greensock.com/forums/topic/16736-textplugin-animation-reverse-in-timelinemax/
https://greensock.com/forums/topic/24752-textplug-in-reveal-direction/