### PR TITLE
fix: Correct deprecation links in gsap-core.d.ts to the right release notes

### DIFF
--- a/types/gsap-core.d.ts
+++ b/types/gsap-core.d.ts
@@ -657,25 +657,25 @@ declare namespace gsap {
 // TODO: Move to files where declared
 /**
  * @deprecated since 3.0.0
- * @link https://greensock.com/3-migration/
+ * @link https://greensock.com/3-release-notes/
  */
 declare class TweenLite extends gsap.core.Tween {}
 
 /**
  * @deprecated since 3.0.0
- * @link https://greensock.com/3-migration/
+ * @link https://greensock.com/3-release-notes/
  */
 declare class TweenMax extends gsap.core.Tween {}
 
 /**
  * @deprecated since 3.0.0
- * @link https://greensock.com/3-migration/
+ * @link https://greensock.com/3-release-notes/
  */
 declare class TimelineLite extends gsap.core.Timeline {}
 
 /**
  * @deprecated since 3.0.0
- * @link https://greensock.com/3-migration/
+ * @link https://greensock.com/3-release-notes/
  */
 declare class TimelineMax extends gsap.core.Timeline {}
 
@@ -686,25 +686,25 @@ declare module "gsap/gsap-core" {
   // TODO: Move to files where declared
   /**
    * @deprecated since 3.0.0
-   * @link https://greensock.com/3-migration/
+   * @link https://greensock.com/3-release-notes/
    */
   export class TweenLite extends gsap.core.Tween {}
 
   /**
    * @deprecated since 3.0.0
-   * @link https://greensock.com/3-migration/
+   * @link https://greensock.com/3-release-notes/
    */
   export class TweenMax extends gsap.core.Tween {}
 
   /**
    * @deprecated since 3.0.0
-   * @link https://greensock.com/3-migration/
+   * @link https://greensock.com/3-release-notes/
    */
   export class TimelineLite extends gsap.core.Timeline {}
 
   /**
    * @deprecated since 3.0.0
-   * @link https://greensock.com/3-migration/
+   * @link https://greensock.com/3-release-notes/
    */
   export class TimelineMax extends gsap.core.Timeline {}
 


### PR DESCRIPTION
### Update deprecated links in gsap-core.d.ts to point to the correct release notes.

The link https://greensock.com/3-migration/ leads to a ‘Not Found’ page, and I believe https://greensock.com/blog/3-release-notes is the most suitable replacement.